### PR TITLE
Avoid audiocontext creation on load

### DIFF
--- a/src/chronoid/core.cljs
+++ b/src/chronoid/core.cljs
@@ -1,8 +1,7 @@
 (ns chronoid.core)
 
 (def default-options
-  {;:context *audio-context*
-   :tolerance-late  100 ; ms
+  {:tolerance-late  100 ; ms
    :tolerance-early 1}) ; ms
 
 (def ^:dynamic *clocks* {})

--- a/src/chronoid/core.cljs
+++ b/src/chronoid/core.cljs
@@ -1,17 +1,12 @@
 (ns chronoid.core)
 
-(def ^:dynamic *audio-context*
-  (let [ctx (or js/window.AudioContext
-                js/window.webkitAudioContext)]
-    (ctx.)))
-
 (def default-options
-  {:context *audio-context*
+  {;:context *audio-context*
    :tolerance-late  100 ; ms
    :tolerance-early 1}) ; ms
 
 (def ^:dynamic *clocks* {})
-
+(def audio-context (atom nil))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; For all of the public functions, the `clock` arguments are atom references to
@@ -20,10 +15,15 @@
 
 (defn clock
   [& {:as attrs}]
-  (let [id           (gensym "clock")
+  (let [ctx (if @audio-context @audio-context 
+              (let [ct (or js/window.AudioContext js/window.webkitAudioContext)
+                    inst (ct.)]
+                (reset! audio-context inst)))
+        id           (gensym "clock")
         clock        (merge default-options
                             attrs
-                            {:id      id
+                            {:context ctx 
+                             :id      id
                              :events  []
                              :started false})
         atomic-clock (atom clock)]


### PR DESCRIPTION
Certain browsers (e.g. Chrome) are starting to disallow initializing the AudioContext without user interaction.
I've changed the `(clock)` fn to now create the AudioContext if it doesn't exist.